### PR TITLE
Update ViewController to work on iOS 13 with Xcode 11.3

### DIFF
--- a/CoreMLDemo/ViewController.swift
+++ b/CoreMLDemo/ViewController.swift
@@ -59,11 +59,11 @@ extension ViewController: UIImagePickerControllerDelegate {
         dismiss(animated: true, completion: nil)
     }
     
-    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         
         picker.dismiss(animated: true)
         classifier.text = "Analyzing Image..."
-        guard let image = info["UIImagePickerControllerOriginalImage"] as? UIImage else {
+        guard let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else {
             return
         } //1
         


### PR DESCRIPTION
The current code doesn't work on iOS 13 when the selected image doesn't appear in the ImageView. Changing the info parameter of imagePickerController function from string to UIImagePickerController.InfoKey and other appropriate changes corrects the error. 